### PR TITLE
Improved types

### DIFF
--- a/src/DynamoBatch.ts
+++ b/src/DynamoBatch.ts
@@ -1,4 +1,4 @@
-import {DeleteParams, GetParams, Item, KeyAttributes, PutParams} from './types';
+import {DeleteParams, GetParams, Item, KeyAttributes, ProjectionKeys, PutParams} from './types';
 import {BatchGetCommand, BatchGetCommandInput, BatchWriteCommand, BatchWriteCommandInput} from '@aws-sdk/lib-dynamodb';
 import {DynamoWrapper} from './DynamoWrapper';
 import {DynamoModel} from './DynamoModel';
@@ -11,7 +11,7 @@ type BatchItem<T extends Item = Item> = {
 };
 
 export class DynamoBatchStatementProxy extends DynamoWrapper {
-  get<T extends Item, K extends KeyAttributes<T>, P extends keyof T>(
+  get<T extends Item, K extends KeyAttributes<T>, P extends ProjectionKeys<T>>(
       model: DynamoModel<T, K>, ...paramsList: Array<GetParams<T, K, P>>
   ): DynamoBatchGetStatement {
     return new DynamoBatchGetStatement(this.client, this.name).get(model, ...paramsList);
@@ -36,7 +36,7 @@ export class DynamoBatchGetStatement extends DynamoWrapper {
   private requestMap: NonNullable<BatchGetCommandInput['RequestItems']> = {};
   private readonly modelMap = new Map<string, DynamoModel<any>>();
 
-  get<T extends Item, K extends KeyAttributes<T>, P extends keyof T>(
+  get<T extends Item, K extends KeyAttributes<T>, P extends ProjectionKeys<T>>(
       model: DynamoModel<T, K>, ...paramsList: Array<GetParams<T, K, P>>
   ): DynamoBatchGetStatement {
     for (const params of paramsList) {

--- a/src/DynamoModel.ts
+++ b/src/DynamoModel.ts
@@ -12,7 +12,8 @@ import {
   createUpdateRequest,
 } from './requests';
 import {
-  DeleteParams, Extend,
+  DeleteParams,
+  Extend,
   FullProjection,
   GetParams,
   GetResult,

--- a/src/DynamoModel.ts
+++ b/src/DynamoModel.ts
@@ -12,7 +12,7 @@ import {
   createUpdateRequest,
 } from './requests';
 import {
-  DeleteParams,
+  DeleteParams, Extend,
   FullProjection,
   GetParams,
   GetResult,
@@ -330,7 +330,7 @@ export class DynamoModelBuilder<T extends Item, K extends KeyAttributes<T> = nev
    */
   // Ideally this would be item: WrittenItem<T, _B> but then _B cannot be inferred from the return type
   withCreator<_B>(creator: (item: T) => _B) {
-    const builder = this as unknown as DynamoModelBuilder<T & _B, K, I, B & _B>;
+    const builder = this as unknown as DynamoModelBuilder<Extend<T, _B>, K, I, Extend<B, _B>>;
 
     builder.params.creators.push(creator as any);
 

--- a/src/DynamoTransaction.ts
+++ b/src/DynamoTransaction.ts
@@ -6,7 +6,16 @@ import {
   TransactWriteCommandInput,
 } from '@aws-sdk/lib-dynamodb';
 
-import {ConditionCheckParams, DeleteParams, GetParams, Item, KeyAttributes, PutParams, UpdateParams} from './types';
+import {
+  ConditionCheckParams,
+  DeleteParams,
+  GetParams,
+  Item,
+  KeyAttributes,
+  ProjectionKeys,
+  PutParams,
+  UpdateParams
+} from './types';
 import {
   createConditionCheckRequest,
   createDeleteRequest,
@@ -40,7 +49,7 @@ export class DynamoTransactionProxy extends DynamoWrapper {
     return new DynamoWriteTransaction(this.client, this.name).delete(model, ...paramsList);
   }
 
-  get<T extends Item, K extends KeyAttributes<T>, P extends keyof T>(
+  get<T extends Item, K extends KeyAttributes<T>, P extends ProjectionKeys<T>>(
       model: DynamoModel<T, K>,
       ...paramsList: Array<GetParams<T, K, P>>
   ): DynamoGetTransaction {
@@ -79,7 +88,7 @@ export abstract class DynamoTransaction extends DynamoWrapper {
 export class DynamoGetTransaction extends DynamoTransaction {
   private readonly items: NonNullable<TransactGetCommandInput['TransactItems']> = [];
 
-  get<T extends Item, K extends KeyAttributes<T>, P extends keyof T>(
+  get<T extends Item, K extends KeyAttributes<T>, P extends ProjectionKeys<T>>(
       model: DynamoModel<T, K>,
       ...paramsList: Array<GetParams<T, K, P>>
   ): DynamoGetTransaction {

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -19,9 +19,9 @@ import {buildConditionExpression, buildUpdateExpression} from 'dynamodb-expressi
 import {DynamoModel} from './DynamoModel';
 import {parsePageToken} from './utils';
 
-export function createGetRequest<T extends Item, K extends KeyAttributes<T>, P extends ProjectionKeys<T>>(
+export function createGetRequest<T extends Item, K extends KeyAttributes<T>, P extends ProjectionKeys<T2>, T2 extends T = T>(
     model: DynamoModel<T>,
-    params: GetParams<T, K, P>
+    params: GetParams<T2, K, P>
 ): GetCommandInput {
   const {key, projection, consistency} = params;
   return {
@@ -32,9 +32,9 @@ export function createGetRequest<T extends Item, K extends KeyAttributes<T>, P e
   };
 }
 
-export function createScanRequest<T extends Item, P extends ProjectionKeys<T>, N extends string, F extends ProjectionKeys<T>>(
+export function createScanRequest<T extends Item, P extends ProjectionKeys<T2>, N extends string, F extends ProjectionKeys<T2>, T2 extends T = T>(
     model: DynamoModel<T>,
-    params: ScanParams<T, P, N, F>,
+    params: ScanParams<T2, P, N, F>,
 ): ScanCommandInput {
   const attr = {};
   const {
@@ -58,9 +58,9 @@ export function createScanRequest<T extends Item, P extends ProjectionKeys<T>, N
   };
 }
 
-export function createQueryRequest<T extends Item, P extends ProjectionKeys<T>, N extends string, I extends keyof T>(
+export function createQueryRequest<T extends Item, P extends ProjectionKeys<T2>, N extends string, I extends keyof T, T2 extends T = T>(
     model: DynamoModel<T>,
-    params: QueryParams<T, P, N, I>
+    params: QueryParams<T2, P, N, I>
 ): QueryCommandInput {
   const attr = {};
   const {
@@ -88,9 +88,9 @@ export function createQueryRequest<T extends Item, P extends ProjectionKeys<T>, 
   };
 }
 
-export function createPutRequest<T extends Item, B extends Item>(
+export function createPutRequest<T extends Item, B extends Item, T2 extends T = T>(
     model: DynamoModel<T>,
-    params: PutParams<T, B>
+    params: PutParams<T2, B>
 ): PutCommandInput {
   const attr = {};
   const {item, conditions} = params;
@@ -105,9 +105,9 @@ export function createPutRequest<T extends Item, B extends Item>(
   };
 }
 
-export function createUpdateRequest<T extends Item, K extends KeyAttributes<T>, B extends Item>(
+export function createUpdateRequest<T extends Item, K extends KeyAttributes<T>, B extends Item, T2 extends T = T>(
     model: DynamoModel<T, K>,
-    params: UpdateParams<T, K, B>
+    params: UpdateParams<T2, K, B>
 ) {
   const attr = {};
   const {key, attributes, conditions} = params;

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -1,14 +1,5 @@
 import {ConditionCheck} from '@aws-sdk/client-dynamodb';
 import {
-  ConditionCheckParams,
-  DeleteParams,
-  GetParams, Item,
-  KeyAttributes, ProjectionKeys, PutParams,
-  QueryParams,
-  ScanParams,
-  UpdateParams,
-} from './types';
-import {
   DeleteCommandInput,
   GetCommandInput,
   PutCommandInput,
@@ -17,6 +8,18 @@ import {
 } from '@aws-sdk/lib-dynamodb';
 import {buildConditionExpression, buildUpdateExpression} from 'dynamodb-expressions';
 import {DynamoModel} from './DynamoModel';
+import {
+  ConditionCheckParams,
+  DeleteParams,
+  GetParams,
+  Item,
+  KeyAttributes,
+  ProjectionKeys,
+  PutParams,
+  QueryParams,
+  ScanParams,
+  UpdateParams,
+} from './types';
 import {parsePageToken} from './utils';
 
 export function createGetRequest<T extends Item, K extends KeyAttributes<T>, P extends ProjectionKeys<T2>, T2 extends T = T>(

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -3,7 +3,7 @@ import {
   ConditionCheckParams,
   DeleteParams,
   GetParams, Item,
-  KeyAttributes, PutParams,
+  KeyAttributes, ProjectionKeys, PutParams,
   QueryParams,
   ScanParams,
   UpdateParams,
@@ -19,7 +19,7 @@ import {buildConditionExpression, buildUpdateExpression} from 'dynamodb-expressi
 import {DynamoModel} from './DynamoModel';
 import {parsePageToken} from './utils';
 
-export function createGetRequest<T extends Item, K extends KeyAttributes<T>, P extends keyof T>(
+export function createGetRequest<T extends Item, K extends KeyAttributes<T>, P extends ProjectionKeys<T>>(
     model: DynamoModel<T>,
     params: GetParams<T, K, P>
 ): GetCommandInput {
@@ -32,7 +32,7 @@ export function createGetRequest<T extends Item, K extends KeyAttributes<T>, P e
   };
 }
 
-export function createScanRequest<T extends Item, P extends keyof T, N extends string, F extends keyof T>(
+export function createScanRequest<T extends Item, P extends ProjectionKeys<T>, N extends string, F extends ProjectionKeys<T>>(
     model: DynamoModel<T>,
     params: ScanParams<T, P, N, F>,
 ): ScanCommandInput {
@@ -58,7 +58,7 @@ export function createScanRequest<T extends Item, P extends keyof T, N extends s
   };
 }
 
-export function createQueryRequest<T extends Item, P extends keyof T, N extends string, I extends keyof T>(
+export function createQueryRequest<T extends Item, P extends ProjectionKeys<T>, N extends string, I extends keyof T>(
     model: DynamoModel<T>,
     params: QueryParams<T, P, N, I>
 ): QueryCommandInput {

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ import {StringKeyOf} from './utils';
 export type Item = Record<string, any>;
 type DistributedOmit<T, K extends keyof any> = T extends any ? Omit<T, K> : never;
 type Optional<T extends Item, B extends Item> = DistributedOmit<T, keyof B> & Partial<B>;
+export type Extend<T, B> = T extends B ? T : T & B;
 
 export type FullProjection = null;
 export type ProjectionKeys<T> = keyof T | FullProjection;

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,8 +7,8 @@ import {StringKeyOf} from './utils';
 
 export type Item = Record<string, any>;
 type DistributedOmit<T, K extends keyof any> = T extends any ? Omit<T, K> : never;
-export type KeyOf<T> = T extends any ? keyof T : never;
 type Optional<T extends Item, B extends Item> = DistributedOmit<T, keyof B> & Partial<B>;
+
 export type FullProjection = null;
 export type ProjectionKeys<T> = keyof T | FullProjection;
 export type Projection<T, K extends ProjectionKeys<T>> = [K] extends [null] ? T : [K] extends [keyof T] ? Pick<T, K> : never;
@@ -16,27 +16,11 @@ export type Projection<T, K extends ProjectionKeys<T>> = [K] extends [null] ? T 
 const TYPE_TOKEN = Symbol();
 
 export type TypeToken<T> = T;
+
 export function as<T>(): TypeToken<T> {
   return TYPE_TOKEN as T;
 }
 
-// T : K
-// extends KeyOf<T> ?
-// Pick<T, K> : never;
-
-// type Foo = {a: 'FOO', b: number}
-// type Bar = {a: 'BAR', c: string}
-// type X = Foo | Bar;
-// type A = Projection<X, 'a'|'c'|'b'>;
-// function foo(a: A) {
-//   if (a.a === 'BAR') {
-//     a.c
-//   } else {
-//     a.b
-//   }
-//   a.b
-// }
-// const a: A = {a: 'FOO'}
 /**
  * The name of an attribute within K
  */
@@ -90,8 +74,11 @@ export type ModelParams<T extends Item, K extends KeyAttributes<T>, I extends Ke
 
 export type ConsistencyLevel = 'eventual' | 'strong';
 
-export interface GetParams<T extends Item, K extends KeyAttributes<T>, P extends ProjectionKeys<T> = null> {
+interface Typable<T> {
   type?: TypeToken<T>;
+}
+
+export interface GetParams<T extends Item, K extends KeyAttributes<T>, P extends ProjectionKeys<T> = null> extends Typable<T> {
   key: KeyValue<T, K>;
   projection?: P[];
   consistency?: ConsistencyLevel;
@@ -108,8 +95,8 @@ export interface ScanResult<T extends Item, P extends ProjectionKeys<T> = null> 
   nextPageToken?: string
 }
 
-export interface ScanParams<T extends Item, P extends ProjectionKeys<T> = null, N extends string | undefined = string | undefined, F extends ProjectionKeys<T> = null> {
-  type?: TypeToken<T>;
+export interface ScanParams<T extends Item, P extends ProjectionKeys<T> = null, N extends string | undefined = string | undefined, F extends ProjectionKeys<T> = null>
+  extends Typable<T> {
   indexName?: N;
   pageToken?: string;
   limit?: number;
@@ -125,8 +112,7 @@ export interface QueryParams<T extends Item, P extends ProjectionKeys<T> = null,
   ascending?: boolean;
 }
 
-export interface PutParams<T extends Item, B extends Item> {
-  type?: TypeToken<T>;
+export interface PutParams<T extends Item, B extends Item> extends Typable<T> {
   item: Optional<T, B>;
   conditions?: ConditionSet<T>;
 }
@@ -136,7 +122,7 @@ export interface DeleteParams<T extends Item, K extends KeyAttributes<T>> {
   conditions?: ConditionSet<T>;
 }
 
-export interface UpdateParams<T extends Item, K extends KeyAttributes<T>, B extends Item> {
+export interface UpdateParams<T extends Item, K extends KeyAttributes<T>, B extends Item> extends Typable<T> {
   key: KeyValue<T, K>;
   attributes: UpdateAttributes<Optional<T, B>>;
   conditions?: ConditionSet<T>;


### PR DESCRIPTION
* Improved typings for model data represented as unions 
* Increased readability of merged types
* Added downcast option to scan/query/get/update

If a model represents multiple different types of data, as is common with NOSQL modelling, then the type T of a model will typically be a union type.
Due to how the standard Pick and Omit types do not distribute over unions, this caused some problems, since all calls returning data used `Pick<T, P>` which does not distribute, resulting in returning only the attributes found in all possible types of the union. This is now fixed using a distributed type, and by using `null` to denote "full projection", all the ugly return types such as `Pick<Foo, 'a'|'b'|'c'|'d'|'e'|'f'>` for the default full projections are avoided and the return type for a full projection is simply `Foo`.

Also, added a way to explicitly downcast data when knowing that this is safe.
For example, if a table contains two types of data - `Foo` and `Bar` distinguishable by an `itemType` discriminator attribute,  and the model is then defined as `Model<Foo | Bar>`, and querying for `itemType: 'foo'`, then it's now possible to request that the returned items are of type `Foo` instead of `Foo | Bar`:

```
const { items } = await model.query({
  type: as<Foo>(),
  keyCondition: {
    itemType: 'foo'
  }
};

// typeof items is Foo[]
```

This is essentially the same as 

```
const res = await model.query({
  keyCondition: {
    itemType: 'foo'
  }
};

const items = res.items as Foo[];
```

This avoids having to downcast data separately, which is cumbersome with destructuring, and makes it clearer since the type hint is passed in the same parameters as the key condition that effectively implements the filtering of items to the specific type given.

Furthermore, If using `withCreator()` to automatically add attributes such as timestamps, the types are now clearer, especially if the model data type already includes the timestamp attributes:

```
interface TimestampAttributes {
  createdAt: string;
  updatedAt: string;
}

interface Foo extends TimestampAttributes {
  id: string;
  ...
}

class FooModel extends DynamoClient.model<Foo>()
  .withKey('id')
  .withCreator<TimestampAttributes>(item => ({createdAt: now(), updatedAt: now()}))
  .withUpdater(item => Object.assign(item, {updatedAt: now()}))
  .class() {}
```

Now, since `Foo` already extends `TimestampAttributes`, the type `T` of the model will simply be `Foo` instead of `Foo & TimestampAttributes`, which makes working with the model clearer.

and properly distributes across unions.