### PR TITLE
Add support for table metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,3 +310,27 @@ const { items } = await model.query({
 
 return items.map(item => item.something); // item is of type Bar
 ```
+
+### Table metrics
+
+Each operation on a table stores the consumed capacity of that operation (read and write) in the DynamoClient instance,
+so that it's easy to get metrics for each table.
+
+```
+const client = new DynamoClient();
+const persons = new PersonModel(client, 'persons');
+const products = new ProductModel(client, 'products');
+
+await persons.get(...)
+await persons.update(...)
+await persons.put(...)
+await products.update(...)
+await products.put(...)
+await persons.put(...)
+await client.batch().put(..., ...)
+
+const metrics = client.getTableMetrics();
+// returns e.g. persons => {rcu: 20, wcu: 50}, products => {rcu: 4, wcu: 10}
+```
+
+To clear the metrics, use `client.clearTableMetrics()`.

--- a/src/DynamoClient.ts
+++ b/src/DynamoClient.ts
@@ -29,9 +29,28 @@ export interface Options {
 }
 
 /**
+ * Metrics for a table
+ */
+export interface TableMetrics {
+  /**
+   * The name of the table
+   */
+  tableName: string;
+  /**
+   * The consumed read capacity units
+   */
+  rcu: number;
+  /**
+   * The consumed write capacity units
+   */
+  wcu: number;
+}
+
+/**
  * A DynamoDB client
  */
 export class DynamoClient {
+  private tableMetrics = new Map<string, TableMetrics>();
 
   /**
    * Create a model for a DynamoDB table without supplying the runtime parameters.
@@ -70,6 +89,20 @@ export class DynamoClient {
    */
   batch(name?: string): DynamoBatchStatementProxy {
     return new DynamoBatchStatementProxy(this, name);
+  }
+
+  /**
+   * Get metrics for each table operated on by this client instance
+   */
+  getTableMetrics(): Map<string, TableMetrics> {
+    return this.tableMetrics;
+  }
+
+  /**
+   * Clear the table metrics
+   */
+  clearTableMetrics(): void {
+    this.tableMetrics.clear();
   }
 }
 


### PR DESCRIPTION
Log the consumed capacity of each operation, and offer a way to get the accumulated metrics for each table from the client instance.